### PR TITLE
Call verification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ $mock->shouldNotHaveBeenCalled('foo');
 
 ## Authors
 
-Pablo Díez - <pablodip@gmail.com>
-Tobias Marstaller <tobias.marstaller@gmail.com>
+* Pablo Díez - <pablodip@gmail.com>
+* Tobias Marstaller <tobias.marstaller@gmail.com>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $stub->canBeCalled()->with('foo')->andReturn('bar');
 
 // verifying calls
 $mock = new MockeryCallableMock();
-$mock('bar);
+$mock('bar');
 
 $mock->shouldHaveBeenCalled()->with('bar');
 $mock->shouldNotHaveBeenCalled('foo');

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $mock->shouldNotHaveBeenCalled('foo');
 ## Authors
 
 * Pablo Díez - <pablodip@gmail.com>
-* Tobias Marstaller <tobias.marstaller@gmail.com>
+* Tobias Marstaller - <tobias.marstaller@gmail.com>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,19 @@ $retval = $mock();
 $stub = new MockeryCallableMock();
 
 $stub->canBeCalled()->with('foo')->andReturn('bar');
+
+// verifying calls
+$mock = new MockeryCallableMock();
+$mock('bar);
+
+$mock->shouldHaveBeenCalled()->with('bar');
+$mock->shouldNotHaveBeenCalled('foo');
 ```
 
-## Author
+## Authors
 
 Pablo Díez - <pablodip@gmail.com>
+Tobias Marstaller <tobias.marstaller@gmail.com>
 
 ## License
 

--- a/src/MockeryCallableMock.php
+++ b/src/MockeryCallableMock.php
@@ -2,6 +2,7 @@
 
 namespace Akamon\MockeryCallableMock;
 
+use Mockery\Exception\InvalidCountException;
 use Mockery\MockInterface;
 
 class MockeryCallableMock
@@ -14,24 +15,37 @@ class MockeryCallableMock
         $this->mock = \Mockery::mock($this);
     }
 
+    /**
+     * @return \Mockery\Expectation
+     */
     public function shouldBeCalled()
     {
         return $this->mock->shouldReceive('__invoke');
     }
 
+    /**
+     * @return \Mockery\Expectation
+     */
     public function canBeCalled()
     {
         return $this->mock->shouldReceive('__invoke');
     }
 
+    /**
+     * @return \Mockery\Expectation
+     */
     public function shouldHaveBeenCalled()
     {
         return $this->mock->shouldHaveReceived('__invoke');
     }
-    
-    public function shouldNotHaveBeenCalled()
+
+    /**
+     * @return void
+     * @throws InvalidCountException
+     */
+    public function shouldNotHaveBeenCalled(...$args)
     {
-        return $this->mock->shouldNotHaveReceived('__invoke');
+        $this->mock->shouldNotHaveReceived('__invoke', empty($args)? null : $args);
     }
 
     /**

--- a/src/MockeryCallableMock.php
+++ b/src/MockeryCallableMock.php
@@ -24,6 +24,16 @@ class MockeryCallableMock
         return $this->mock->shouldReceive('__invoke');
     }
 
+    public function shouldHaveBeenCalled()
+    {
+        return $this->mock->shouldHaveReceived('__invoke');
+    }
+    
+    public function shouldNotHaveBeenCalled()
+    {
+        return $this->mock->shouldNotHaveReceived('__invoke');
+    }
+
     /**
      * @deprecated
      */

--- a/src/Tests/MockeryCallableMockTest.php
+++ b/src/Tests/MockeryCallableMockTest.php
@@ -3,6 +3,7 @@
 namespace Akamon\MockeryCallableMock\Tests;
 
 use Akamon\MockeryCallableMock\MockeryCallableMock;
+use Mockery\Exception\InvalidCountException;
 
 class MockeryCallableMockTest extends \PHPUnit_Framework_TestCase
 {
@@ -51,5 +52,51 @@ class MockeryCallableMockTest extends \PHPUnit_Framework_TestCase
 
         $mock->shouldBeCalled()->andReturn('foo');
         $this->assertSame('foo', $mock());
+    }
+
+    public function testShouldHaveBeenCalled()
+    {
+        $mock = new MockeryCallableMock();
+
+        $mock->canBeCalled()->withAnyArgs()->andReturn('foo');
+        $mock('bar');
+
+        $mock->shouldHaveBeenCalled()->with('bar');
+    }
+
+    /**
+ * @expectedException \Mockery\Exception\InvalidCountException
+ */
+    public function testShouldNotHaveBeenCalled()
+    {
+        $mock = new MockeryCallableMock();
+
+        $mock->canBeCalled()->withAnyArgs()->andReturn('foo');
+        $mock();
+
+        $mock->shouldNotHaveBeenCalled();
+    }
+
+    /**
+     * @expectedException \Mockery\Exception\InvalidCountException
+     */
+    public function testShouldNotHaveBeenCalledWithMatchingArgs()
+    {
+        $mock = new MockeryCallableMock();
+
+        $mock->canBeCalled()->withAnyArgs()->andReturn('foo');
+        $mock('bar');
+
+        $mock->shouldNotHaveBeenCalled('bar');
+    }
+    
+    public function testShouldNotHaveBeenCalledWithNonMatchingArgs()
+    {
+        $mock = new MockeryCallableMock();
+
+        $mock->canBeCalled()->withAnyArgs()->andReturn('foo');
+        $mock('bar');
+
+        $mock->shouldNotHaveBeenCalled('bob');
     }
 }


### PR DESCRIPTION
This adds support for call verification:

```php
$mock->shouldHaveBeenCalled()->with(anything());
$mock->shouldNotHaveBeenCalled('foo', 'bar');
```